### PR TITLE
Marcin/fix fully correlated conditional repeat shapes

### DIFF
--- a/gpflow/multioutput/conditionals.py
+++ b/gpflow/multioutput/conditionals.py
@@ -405,7 +405,7 @@ def fully_correlated_conditional_repeat(Kmn, Kmm, Knn, f, *, full_cov=False, ful
         fvar = Knn - tf.matmul(At, At, transpose_a=True)  # N x K x K
     elif not full_cov and not full_output_cov:
         # Knn: N x K
-        fvar = Knn - tf.reshape(tf.reduce_sum(tf.square(A), [0]), (N, K))  # Can also do this with a matmul
+        fvar = Knn - tf.reshape(tf.reduce_sum(tf.square(A), [0]), (1, N, K))  # Can also do this with a matmul
 
     # another backsubstitution in the unwhitened case
     if not white:

--- a/tests/test_multioutput.py
+++ b/tests/test_multioutput.py
@@ -11,6 +11,8 @@ from gpflow.features import InducingPoints
 from gpflow.kernels import RBF
 from gpflow.likelihoods import Gaussian
 from gpflow.models import SVGP
+from gpflow.multioutput.conditionals import fully_correlated_conditional_repeat, \
+    fully_correlated_conditional, independent_interdomain_conditional
 from gpflow.test_util import session_tf
 from gpflow.training import ScipyOptimizer
 from gpflow.conditionals import _sample_mvn, sample_conditional
@@ -288,6 +290,29 @@ def test_sample_conditional_mixedkernel(session_tf):
                                          np.mean(value2, axis=0), decimal=1)
     np.testing.assert_array_almost_equal(np.cov(value, rowvar=False),
                                          np.cov(value2, rowvar=False), decimal=1)
+
+
+@pytest.mark.parametrize("func", [fully_correlated_conditional_repeat,
+                                  fully_correlated_conditional])
+def test_fully_correlated_conditional_repeat_shapes(func):
+    L, M, N, P = Data.L, Data.M, Data.N, Data.P
+    R = 1
+
+    Kmm = tf.ones((L * M, L * M))
+    Kmn = tf.ones((L * M, N, P))
+    Knn = tf.ones((N, P))
+    f = tf.ones((L * M, R))
+    q_sqrt = None
+    white = True
+
+    m, v = func(Kmn, Kmm, Knn, f,
+                full_cov=False,
+                full_output_cov=False,
+                q_sqrt=q_sqrt,
+                white=white)
+
+    assert v.shape == m.shape
+
 
 # ------------------------------------------
 # Test Mixed Mok Kgg

--- a/tests/test_multioutput.py
+++ b/tests/test_multioutput.py
@@ -311,7 +311,7 @@ def test_fully_correlated_conditional_repeat_shapes(func):
                 q_sqrt=q_sqrt,
                 white=white)
 
-    assert v.shape == m.shape
+    assert v.shape.as_list() == m.shape.as_list()
 
 
 # ------------------------------------------


### PR DESCRIPTION
Fix shapes returned by `fully_correlated_conditional_repeat`

There's inconsistency between shapes of `fmean` and `fvar` returned by `fully_correlated_conditional_repeat`. This causes problems with downstream functions for sampling.

Minimal working example:

This test catches the bug:
```
@pytest.mark.parametrize("func", [fully_correlated_conditional_repeat,
                                  fully_correlated_conditional])
def test_fully_correlated_conditional_repeat_shapes(func):
    L, M, N, P = Data.L, Data.M, Data.N, Data.P
    R = 1

    Kmm = tf.ones((L * M, L * M))
    Kmn = tf.ones((L * M, N, P))
    Knn = tf.ones((N, P))
    f = tf.ones((L * M, R))
    q_sqrt = None
    white = True

    m, v = func(Kmn, Kmm, Knn, f,
                full_cov=False,
                full_output_cov=False,
                q_sqrt=q_sqrt,
                white=white)

    assert v.shape == m.shape
```
Output before fix:
```
func = <function fully_correlated_conditional at 0x7ff689444268>

    @pytest.mark.parametrize("func", [fully_correlated_conditional_repeat,
                                      fully_correlated_conditional])
    def test_fully_correlated_conditional_repeat_shapes(func):
        L, M, N, P = Data.L, Data.M, Data.N, Data.P
        R = 1
    
        Kmm = tf.ones((L * M, L * M))
        Kmn = tf.ones((L * M, N, P))
        Knn = tf.ones((N, P))
        f = tf.ones((L * M, R))
        q_sqrt = None
        white = True
    
        m, v = func(Kmn, Kmm, Knn, f,
                    full_cov=False,
                    full_output_cov=False,
                    q_sqrt=q_sqrt,
                    white=white)
    
>       assert v.shape.as_list() == m.shape.as_list()
E       assert [3] == [20, 3]
E         At index 0 diff: 3 != 20
E         Right contains more items, first extra item: 3
E         Use -v to get the full diff

tests/test_multioutput.py:314: AssertionError
```
